### PR TITLE
Quote the file mode for compatibility with Puppet4.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -52,7 +52,7 @@ class kibana::install (
     file { '/etc/init.d/kibana':
       ensure  => 'file',
       content => template('kibana/kibana.legacy.service.erb'),
-      mode    => 0755,
+      mode    => '0755',
     }
   } else {
     file { '/usr/lib/systemd/system/kibana.service':


### PR DESCRIPTION
We use Puppet 4 and we get:-

```
Error: Failed to apply catalog: Parameter mode failed on File[/etc/init.d/kibana]: The file mode specification must be a string, not 'Fixnum' at /etc/puppetlabs/code/environments/production/modules/kibana/manifests/install.pp:52
```

with this module because the file mode needs to be quoted in Puppet 4.