### PR TITLE
define default-start for legacy init script

### DIFF
--- a/templates/kibana.legacy.service.lsbheader.erb
+++ b/templates/kibana.legacy.service.lsbheader.erb
@@ -9,7 +9,7 @@
 # Provides: kibana
 # Required-Start: $all
 # Required-Stop: $all
-# Default-Start:
+# Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Short-Description: Kibana
 # Description: Kibana is a web interface to Logstash.


### PR DESCRIPTION
Allow to enable service at boottime on debian based systems.
Puppet use command 'update-rc.d $NAME defaults' which silently
failed without defined Default-Start. So puppet try to enabled
service at every run.