### PR TITLE
allow verify_ssl to be configured

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,10 @@
 #   Boolean.
 #   Default: false
 #
+# [*verify_ssl*]
+#   Boolean.
+#   Default: true
+#
 # === Examples
 #
 # * Installation:
@@ -79,6 +83,7 @@ class kibana (
   $default_app_id      = $::kibana::params::default_app_id,
   $request_timeout     = $::kibana::params::request_timeout,
   $shard_timeout       = $::kibana::params::shard_timeout,
+  $verify_ssl          = $::kibana::params::verify_ssl,
 ) inherits kibana::params {
 
   if !is_integer($port) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class kibana::params {
   $request_timeout     = 300000
   $shard_timeout       = 0
   $group               = 'kibana'
+  $verify_ssl          = true
   $user                = 'kibana'
 
   case $::operatingsystem {

--- a/templates/kibana.yml.erb
+++ b/templates/kibana.yml.erb
@@ -39,7 +39,7 @@ shard_timeout: <%= @shard_timeout %>
 
 # Set to false to have a complete disregard for the validity of the SSL
 # certificate.
-verify_ssl: true
+verify_ssl: <%= @verify_ssl %>
 
 # If you need to provide a CA certificate for your Elasticsarech instance, put
 # the path of the pem file here.


### PR DESCRIPTION
Not sure how you would like to handle this one. It may be better off as a feature enhancement to allow setting/overriding any config property in the kibana.yml file.

At least for now my main need is to allow ssl verification to be toggled off. The default is preserved.