### PR TITLE
sheild ssl + credentials pickup from pabrahamsson

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,15 +8,22 @@
 # * Justin Lambert <mailto:jlambert@letsevenup.com>
 #
 class kibana::config (
-  $install_path     = $::kibana::install_path,
-  $port             = $::kibana::port,
-  $bind             = $::kibana::bind,
-  $es_url           = $::kibana::es_url,
-  $es_preserve_host = $::kibana::es_preserve_host,
-  $kibana_index     = $::kibana::kibana_index,
-  $default_app_id   = $::kibana::default_app_id,
-  $request_timeout  = $::kibana::request_timeout,
-  $shard_timeout    = $::kibana::shard_timeout,
+  $install_path           = $::kibana::install_path,
+  $port                   = $::kibana::port,
+  $bind                   = $::kibana::bind,
+  $ca_cert                = $::kibana::ca_cert,
+  $es_url                 = $::kibana::es_url,
+  $es_preserve_host       = $::kibana::es_preserve_host,
+  $kibana_index           = $::kibana::kibana_index,
+  $elasticsearch_username = $::kibana::elasticsearch_username,
+  $elasticsearch_password = $::kibana::elasticsearch_password,
+  $default_app_id         = $::kibana::default_app_id,
+  $pid_file               = $::kibana::pid_file,
+  $request_timeout        = $::kibana::request_timeout,
+  $shard_timeout          = $::kibana::shard_timeout,
+  $ssl_cert_file          = $::kibana::ssl_cert_file,
+  $ssl_key_file           = $::kibana::ssl_key_file,
+  $verify_ssl             = $::kibana::verify_ssl,
 ){
 
   file { "${install_path}/kibana/config/kibana.yml":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,9 +12,25 @@
 #   String.  HTTP path to fetch kibana package from
 #   Default: https://download.elasticsearch.org/kibana/kibana
 #
+# [*ca_cert*]
+#   String: Path to ca cert (PEM formatted)
+#   Default: undef
+#
 # [*tmp_dir*]
 #   String.  Working dir for caching package
 #   Default: /tmp
+#
+# [*elasticsearch_username*}
+#   String. The Elasticsearch user
+#   Default: undef
+#
+# [*elasticsearch_password*]
+#   String. The Elasticsearch password
+#   Default: undef
+#
+# [*pid_file*]
+#   String. Path to the pid file
+#   Defailt: /var/run/kibana.pid
 #
 # [*install_path*]
 #   String.  Location to install kibana
@@ -48,6 +64,14 @@
 #   Integer.  Time in milliseconds to wait for responses from the back end or elasticsearch.
 #   Default: 300000
 #
+# [*ssl_cert_file*]
+#   String. Path to ssl key file (PEM formatted).
+#   Default: undef
+#
+# [*ssl_key_file*]
+#   String. Path to ssl cert file (PEM formatted).
+#   Default: undef
+#
 # [*shard_timeout*]
 #   String.  Time in milliseconds for Elasticsearch to wait for responses from shards.
 #   Default: 0
@@ -71,19 +95,25 @@
 # * Justin Lambert <mailto:jlambert@letsevenup.com>
 #
 class kibana (
-  $version             = $::kibana::params::version,
-  $base_url            = $::kibana::params::base_url,
-  $install_path        = $::kibana::params::install_path,
-  $tmp_dir             = $::kibana::params::tmp_dir,
-  $port                = $::kibana::params::port,
-  $bind                = $::kibana::params::bind,
-  $es_url              = $::kibana::params::es_url,
-  $es_preserve_host    = $::kibana::params::es_preserve_host,
-  $kibana_index        = $::kibana::params::kibana_index,
-  $default_app_id      = $::kibana::params::default_app_id,
-  $request_timeout     = $::kibana::params::request_timeout,
-  $shard_timeout       = $::kibana::params::shard_timeout,
-  $verify_ssl          = $::kibana::params::verify_ssl,
+  $version                       = $::kibana::params::version,
+  $base_url                      = $::kibana::params::base_url,
+  $ca_cert                       = $::kibana::params::ca_cert,
+  $install_path                  = $::kibana::params::install_path,
+  $tmp_dir                       = $::kibana::params::tmp_dir,
+  $port                          = $::kibana::params::port,
+  $bind                          = $::kibana::params::bind,
+  $es_url                        = $::kibana::params::es_url,
+  $es_preserve_host              = $::kibana::params::es_preserve_host,
+  $kibana_index                  = $::kibana::params::kibana_index,
+  $elasticsearch_username        = $::kibana::params::elasticsearch_username,
+  $elasticsearch_password        = $::kibana::params::elasticsearch_password,
+  $default_app_id                = $::kibana::params::default_app_id,
+  $pid_file                      = $::kibana::params::pid_file,
+  $request_timeout               = $::kibana::params::request_timeout,
+  $shard_timeout                 = $::kibana::params::shard_timeout,
+  $ssl_cert_file                 = $::kibana::params::ssl_cert_file,
+  $ssl_key_file                  = $::kibana::params::ssl_key_file,
+  $verify_ssl                    = $::kibana::params::verify_ssl,
 ) inherits kibana::params {
 
   if !is_integer($port) {
@@ -97,7 +127,9 @@ class kibana (
   }
   validate_absolute_path($install_path)
   validate_absolute_path($tmp_dir)
+  validate_absolute_path($pid_file)
   validate_bool($es_preserve_host)
+  validate_bool($verify_ssl)
 
   class { '::kibana::install': } ->
   class { '::kibana::config': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,6 +38,7 @@ class kibana::install (
   wget::fetch { 'kibana':
     source      => "${base_url}/${filename}.tar.gz",
     destination => "${tmp_dir}/${filename}.tar.gz",
+    require     => User[$user],
   }
 
   exec { 'extract_kibana':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,22 +8,27 @@
 # * Justin Lambert <mailto:jlambert@letsevenup.com>
 #
 class kibana::params {
-
-  $version             = '4.0.1'
-  $base_url            = 'https://download.elasticsearch.org/kibana/kibana'
-  $install_path        = '/opt'
-  $tmp_dir             = '/tmp'
-  $port                = 5601
-  $bind                = '0.0.0.0'
-  $es_url              = 'http://localhost:9200'
-  $es_preserve_host    = true
-  $kibana_index        = '.kibana'
-  $default_app_id      = 'discover'
-  $request_timeout     = 300000
-  $shard_timeout       = 0
-  $group               = 'kibana'
-  $verify_ssl          = true
-  $user                = 'kibana'
+  $version                = '4.0.1'
+  $base_url               = 'https://download.elasticsearch.org/kibana/kibana'
+  $ca_cert                = undef
+  $install_path           = '/opt'
+  $tmp_dir                = '/tmp'
+  $port                   = 5601
+  $bind                   = '0.0.0.0'
+  $es_url                 = 'http://localhost:9200'
+  $es_preserve_host       = true
+  $kibana_index           = '.kibana'
+  $elasticsearch_username = undef
+  $elasticsearch_password = undef
+  $default_app_id         = 'discover'
+  $pid_file               = '/var/run/kibana.pid'
+  $request_timeout        = 300000
+  $shard_timeout          = 0
+  $ssl_cert_file          = undef
+  $ssl_key_file           = undef
+  $verify_ssl             = true
+  $group                  = 'kibana'
+  $user                   = 'kibana'
 
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLC': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,9 +10,9 @@
 class kibana::service {
 
   service { 'kibana':
-    ensure  => running,
-    enable  => true,
-    require => File['kibana-init-script'],
+    ensure   => running,
+    enable   => true,
+    require  => File['kibana-init-script'],
     provider => $::kibana::params::service_provider,
   }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -9,15 +9,22 @@ describe 'kibana::config', :type => :class do
   } }
 
   let(:params) { {
-    :port             => 5601,
-    :bind             => '0.0.0.0',
-    :es_url           => 'http://localhost:9200',
-    :es_preserve_host => true,
-    :kibana_index     => '.kibana',
-    :default_app_id   => 'discover',
-    :request_timeout  => 30000,
-    :shard_timeout    => 0,
-    :install_path     => '/opt'
+    :port                   => 5601,
+    :bind                   => '0.0.0.0',
+    :ca_cert                => nil,
+    :es_url                 => 'http://localhost:9200',
+    :es_preserve_host       => true,
+    :kibana_index           => '.kibana',
+    :elasticsearch_username => nil,
+    :elasticsearch_password => nil,
+    :default_app_id         => 'discover',
+    :pid_file               => '/var/run/kibana.pid',
+    :request_timeout        => 30000,
+    :shard_timeout          => 0,
+    :ssl_cert_file          => nil,
+    :ssl_key_file           => nil,
+    :verify_ssl             => true,
+    :install_path           => '/opt'
   } }
 
   it { should contain_file('/opt/kibana/config/kibana.yml') }

--- a/templates/kibana.yml.erb
+++ b/templates/kibana.yml.erb
@@ -19,8 +19,12 @@ kibana_index: "<%= @kibana_index %>"
 # used by the Kibana server to perform maintence on the kibana_index at statup. Your Kibana
 # users will still need to authenticate with Elasticsearch (which is proxied thorugh
 # the Kibana server)
-# kibana_elasticsearch_username: user
-# kibana_elasticsearch_password: pass
+<%- if @elasticsearch_username -%>
+kibana_elasticsearch_username: <%= @elasticsearch_username %>
+<%- end -%>
+<%- if @elasticsearch_password -%>
+kibana_elasticsearch_password: <%= @elasticsearch_password %>
+<%- end -%>
 
 
 # The default application to load.
@@ -43,14 +47,16 @@ verify_ssl: <%= @verify_ssl %>
 
 # If you need to provide a CA certificate for your Elasticsarech instance, put
 # the path of the pem file here.
-# ca: /path/to/your/CA.pem
+<%- if @ca_cert -%>
+ca: <%= @ca_cert %>
+<%- end -%>
 
 # SSL for outgoing requests from the Kibana Server (PEM formatted)
 # ssl_key_file: /path/to/your/server.key
 # ssl_cert_file: /path/to/your/server.crt
 
 # Set the path to where you would like the process id file to be created.
-# pid_file: /var/run/kibana.pid
+pid_file: <%= @pid_file %>
 
 # Plugins that are included in the build, and no longer found in the plugins/ folder
 bundled_plugin_ids:


### PR DESCRIPTION
https://github.com/evenup/evenup-kibana/pull/48 is the original pull request. I was having problems getting the merge to go cleanly so just manually re-crafted. Props for the code should go to pabrahamsson

Main changes not in pabrahamsson change set was a lint change for manifests/service.pp. I changed the kibana_elasticsearch_username ... and stripped off the kibana_ prefix, overly wordy IMO.

--

rake test results from local
```
 rake test
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
metadata-json-lint metadata.json
metadata-json-lint metadata.json
Notice: Preparing to install into /Users/bschwanitz/gits/cmm/evenup-kibana/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/Users/bschwanitz/gits/cmm/evenup-kibana/spec/fixtures/modules
└── maestrodev-wget (v1.7.1)
Notice: Preparing to install into /Users/bschwanitz/gits/cmm/evenup-kibana/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Warning: Symlinks in modules are unsupported. Please investigate symlink puppetlabs-stdlib-4.2.0/spec/acceptance/nodesets/default.yml->centos-64-x64.yml.
Notice: Installing -- do not interrupt ...
/Users/bschwanitz/gits/cmm/evenup-kibana/spec/fixtures/modules
└── puppetlabs-stdlib (v4.2.0)
/Users/bschwanitz/.rbenv/versions/2.1.2/bin/ruby -I/Users/bschwanitz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-support-3.1.2/lib:/Users/bschwanitz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib /Users/bschwanitz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\{classes,defines,unit,functions,hosts,integration,types\}/\*\*/\*_spec.rb --color
WARN: Unresolved specs during Gem::Specification.reset:
      rake (>= 0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
............................

Finished in 4.37 seconds (files took 1.16 seconds to load)
28 examples, 0 failures
```