### PR TITLE
Ensure that /usr/lib/systemd/system exists

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -86,6 +86,13 @@ class kibana::install (
 
   if $service_provider == 'systemd' {
 
+    file { '/usr/lib/systemd/system':
+      ensure  => directory,
+      owner   => root,
+      group   => root,
+      mode    => '0755',
+    }
+    ->
     file { 'kibana-init-script':
       ensure  => file,
       path    => '/usr/lib/systemd/system/kibana.service',


### PR DESCRIPTION
This directory does not exist on Ubuntu by default. With this patch the module works on Ubuntu 15.10.