### PR TITLE
Kibana 4 6 support

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,7 +23,7 @@ class kibana::install (
       /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
   }
   }
-  }
+  
   
 
   $service_provider = $::kibana::params::service_provider

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class kibana::install (
   if '4.6' in $version {
     $filename = $::architecture ? {
       /(i386|x86$)/    => "kibana-${version}-linux-x86",
-      /(amd64|x86_64)/ => "kibana-${version}-linux-x86_x64",
+      /(amd64|x86_64)/ => "kibana-${version}-linux-x86_64",
     }
   }
   else {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class kibana::install (
   $group               = $::kibana::group,
   $user                = $::kibana::user,
 ) {
-  if $version >= '4.6' {
+  if $version >= 4.6 {
     $filename = $::architecture ? {
       /(i386|x86$)/    => "kibana-${version}-linux-x86",
       /(amd64|x86_64)/ => "kibana-${version}-linux-x86_x64",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class kibana::install (
   $group               = $::kibana::group,
   $user                = $::kibana::user,
 ) {
-  if $version >= 4.6 {
+  if '4.6' in $version {
     $filename = $::architecture ? {
       /(i386|x86$)/    => "kibana-${version}-linux-x86",
       /(amd64|x86_64)/ => "kibana-${version}-linux-x86_x64",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,11 +11,20 @@ class kibana::install (
   $group               = $::kibana::group,
   $user                = $::kibana::user,
 ) {
-
-  $filename = $::architecture ? {
-    /(i386|x86$)/    => "kibana-${version}-linux-x86",
-    /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
+  if $version >= '4.6' {
+    $filename = $::architecture ? {
+      /(i386|x86$)/    => "kibana-${version}-linux-x86",
+      /(amd64|x86_64)/ => "kibana-${version}-linux-x86_x64",
+    }
   }
+  else {
+    $filename = $::architecture ? {
+      /(i386|x86$)/    => "kibana-${version}-linux-x86",
+      /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
+  }
+  }
+  }
+  
 
   $service_provider = $::kibana::params::service_provider
   $run_path         = $::kibana::params::run_path

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,8 +23,8 @@ class kibana::install (
       /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
   }
   }
-  
-  
+
+
 
   $service_provider = $::kibana::params::service_provider
   $run_path         = $::kibana::params::run_path
@@ -87,7 +87,7 @@ class kibana::install (
     require => User['kibana'],
   }
 
-  if $service_provider == 'init' {
+  if ($service_provider == 'init') or ($service_provider == undef) {
 
     file { 'kibana-init-script':
       ensure  => file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,7 +64,7 @@ class kibana::params {
         $systemd_provider_path = '/usr/lib/systemd/system'
         $run_path              = '/run/kibana'
       } else {
-        $service_provider        = 'init'
+        $service_provider        = undef
         $run_path                = '/var/run'
         $init_script_osdependend = 'kibana.legacy.service.debian.erb'
       }


### PR DESCRIPTION
The url structure for cabana 4.6 is different then previous versions. This change adds a conditional to the install manifest to adjust the url if version 4.6 is specified.
