### PR TITLE
add url support, for offline plugin installation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class kibana::install (
 
   $filename = $::architecture ? {
     /(i386|x86$)/    => "kibana-${version}-linux-x86",
-    /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
+    /(amd64|x86_64)/ => "kibana-${version}-linux-x86_64",
   }
 
   $service_provider = $::kibana::params::service_provider

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -39,10 +39,10 @@ define kibana::plugin(
       $name_file_path = "${plugins_dir}/${base_module_name}/.name"
       exec {"install_plugin_${base_module_name}":
         command => $install_cmd,
-        creates => $name_file_path,
+        creates => ${plugins_dir}/${base_module_name},
         notify  => Service['kibana'],
         require => File[$plugins_dir],
-      }
+      } ->
       file {$name_file_path:
         ensure  => file,
         content => $base_module_name,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,10 +5,15 @@
 #
 class kibana::service {
 
+  $service_provider = $::kibana::params::service_provider ? {
+    'init'  => undef,
+    default => $::kibana::params::service_provider,
+  }
+
   service { 'kibana':
     ensure   => running,
     enable   => true,
     require  => File['kibana-init-script'],
-    provider => $::kibana::params::service_provider,
+    provider => $service_provider,
   }
 }


### PR DESCRIPTION
- the official files from elastic are named *-linux-x86_64
- the provider `init` does not exist, this is default behaviour.
- support for local files are added:

``` yaml
 kibana::plugins:
   'sense':
     'source': 'sense'
     'url': 'http://repository/sense-2.0.0-beta7.tar.gz'
```

and original

``` yaml
 kibana::plugins:
   'sense':
     'source': 'elastic/sense'
```
