### PR TITLE
Add version comparison

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,10 @@ class kibana::install (
 
   $filename = $::architecture ? {
     /(i386|x86$)/    => "kibana-${version}-linux-x86",
-    /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
+    /(amd64|x86_64)/ => versioncmp($version, '4.6.0') ? {
+      /(1|0)/ => "kibana-${version}-linux-x86_64",
+      default => "kibana-${version}-linux-x64",
+    },
   }
 
   $service_provider = $::kibana::params::service_provider

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,13 +11,15 @@ class kibana::install (
   $group               = $::kibana::group,
   $user                = $::kibana::user,
 ) {
+  if versioncmp($version, '4.6.0') < 0 {
+    $arch_string = 'x64'
+  } else {
+    $arch_string = 'x86_64'
+  }
 
   $filename = $::architecture ? {
     /(i386|x86$)/    => "kibana-${version}-linux-x86",
-    /(amd64|x86_64)/ => versioncmp($version, '4.6.0') ? {
-      /(1|0)/ => "kibana-${version}-linux-x86_64",
-      default => "kibana-${version}-linux-x64",
-    },
+    /(amd64|x86_64)/ => "kibana-${version}-linux-${arch_string}",
   }
 
   $service_provider = $::kibana::params::service_provider


### PR DESCRIPTION
This updates the install manifest to update the architecture portion of the tar file based on the version of kibana being installed. 

At 4.6.0 elastic started using the normal x86_64 extension instead of just x64.

Should also note that the base_url for later versions needs to be updated to https://artifacts.elastic.co/downloads/kibana as well, but since this is in params and can be overridden in the class instantiation, I left this as is with the default at 4.0.1. When you update that default version, should update the base_url to reflect as well.
