### PR TITLE
Change in order to set correct arch_suffix

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,11 +10,12 @@ class kibana::install (
   $install_path        = $::kibana::install_path,
   $group               = $::kibana::group,
   $user                = $::kibana::user,
+  $arch_suffix_64bit   = 'x64',
 ) {
 
   $filename = $::architecture ? {
     /(i386|x86$)/    => "kibana-${version}-linux-x86",
-    /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
+    /(amd64|x86_64)/ => "kibana-${version}-linux-${arch_suffix_64bit}",
   }
 
   $service_provider = $::kibana::params::service_provider

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -93,6 +93,10 @@ class kibana::install (
 
   if $service_provider == 'systemd' {
 
+    file { "${::kibana::params::systemd_provider_path}":
+      ensure => directory,
+    }
+
     file { 'kibana-init-script':
       ensure  => file,
       path    => "${::kibana::params::systemd_provider_path}/kibana.service",


### PR DESCRIPTION
Using the following settings in hiera, I managed to install Kibana

kibana::install::arch_suffix_64bit: 'x86_64'
kibana::version: '5.2.0'
kibana::base_url: 'https://artifacts.elastic.co/downloads/kibana'


Server info:
@kibana01:~# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.2 LTS
Release:	16.04
Codename:	xenial

facter facts:
architecture => amd64
puppetversion => 3.8.5
rubyplatform => x86_64-linux-gnu
rubyversion => 2.3.1
is_virtual => true
hardwareisa => x86_64
hardwaremodel => x86_64
